### PR TITLE
Integrated Inline Comment Reply

### DIFF
--- a/js/hnreply.js
+++ b/js/hnreply.js
@@ -1,0 +1,60 @@
+var InlineReply = {
+
+	init: function() {
+		$('a[href^="reply?"]').click(function(e) {
+			e.preventDefault();
+			$(this).hide();
+			link = 'http://news.ycombinator.com/' + $(this).attr('href');
+			$(this).after(
+				'<div class="replyform" style="width:300px;height:100px;position:relative;"> \
+				<textarea rows="4" cols="60" style="height:60px;" /> \
+				<input type ="submit" value="Reply" class="rbutton" \
+				 style="position:absolute;bottom:0px;left:0px;" /> \
+				</div>'
+			);
+			$(this).parent().find('.rbutton').attr('data', link);
+		});
+
+		$('.rbutton').live('click', function(e) {
+			e.preventDefault();
+			link = $(this).attr('data');
+			text = $(this).prev().val();
+			InlineReply.postCommentTo(link, text, $(this));
+		});
+	},
+
+	postCommentTo: function(link, text, button) {
+		InlineReply.disableButtonAndBox(button);
+		$.ajax({
+			accepts: "text/html",
+			url : link
+		}).success(function(html) {
+			input = $(html).find('input');
+			fnid = input.attr('value');
+			InlineReply.sendComment(fnid, text);
+		}).error(function(xhr, status, error) {
+			InlineReply.enableButtonAndBox(button);
+		});
+	},
+
+	sendComment: function(fnidarg, textarg) {
+		$.post(
+			"http://news.ycombinator.com/r", 
+			{fnid : fnidarg, text: textarg }
+		).complete(function(a) {
+			window.location.reload(true);
+		});	
+	},
+
+	disableButtonAndBox: function(button) {
+		button.attr('disabled','disabled');
+		button.prev().attr('disabled', 'disabled');
+	},
+
+	enableButtonAndBox: function(button) {
+		button.removeAttr('disabled');
+		button.prev().removeAttr('disabled');
+	}
+}
+
+InlineReply.init();

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Hacker News Enhancement Suite",
-    "version": "1.1",
+    "version": "1.1.1",
     "description": "Hacker News Enhanced.",
     "background_page": "background_chrome.html",
     "permissions": ["tabs"],
@@ -29,6 +29,11 @@
         "matches": ["http://hckrnews.com/*"],
         "run_at": "document_end",
         "js": ["js/jquery-1.7.2.js", "js/hn.js"]
+      },
+      {
+        "matches" : ["http://news.ycombinator.com/item?*"],
+        "run_at" : "document_end",
+        "js" : ["js/jquery-1.7.2.min.js", "js/hnreply.js"]
       }
     ]
 }


### PR DESCRIPTION
I integrated my small chrome extension, Hacker News Inline Reply, into the Hacker News Enhancement Suite.  I have tested for compatibility, and I have matched the code style of the original HNES project.  There should be no issues with this merge.

I have updated the version in the <code>manifest.json</code> to make this ready to push to the Chrome Web Store.
