### PR TITLE
Added CSS rule to align up/down vote arrows

### DIFF
--- a/style.css
+++ b/style.css
@@ -679,3 +679,9 @@ div.postlist-arrow {
 #others-profile-submitted, #your-profile-change-password {
   padding-top: 2em;
 }
+.comment-table tbody tr td+td center a {
+    float: left;
+    padding-left: 5px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+}


### PR DESCRIPTION
I added a small little rule to align the voting arrows.

Before: http://i.imgur.com/kcSzt0T.png
After: http://i.imgur.com/Pjs8IwK.png
