### PR TITLE
Increase clickable area for story comments link

### DIFF
--- a/style.css
+++ b/style.css
@@ -99,6 +99,9 @@ table tr td {
   top: 7px;
   right: 0px;
 }
+.comments {
+  left: 0;
+}
 /*spacing for comment and score tally*/
 #index-body #content table td:first-child {
   width: 80px;


### PR DESCRIPTION
I found story comment links were a little hard to click on with them being so narrow. This is a small change to increase their size out to the left.

Before:
![](http://i.imgur.com/nI94tsJ.png)

After:
![](http://i.imgur.com/cq621gc.png)
