### PR TITLE
Fix some broken font-family CSS rules

### DIFF
--- a/style.css
+++ b/style.css
@@ -408,7 +408,7 @@ textarea {
 }
 form textarea {
   background: #fff;
-  font-family: font-family: "Helvetica Neue", Arial, sans-serif !important;
+  font-family: "Helvetica Neue", Arial, sans-serif !important;
   font-size: 14px;
   padding: 10px;
   height:80px;
@@ -473,7 +473,7 @@ a.original_poster,
   display: block;
   width: 100%;
   max-width: 800px;
-  font-family: font-family: "Helvetica Neue", Arial, sans-serif !important;
+  font-family: "Helvetica Neue", Arial, sans-serif !important;
   line-height: 1.5em;
 }
 .comment, .dead {
@@ -491,7 +491,7 @@ a.original_poster,
 }
 .comment p,
 .comment > font {
-  font-family: font-family: "Helvetica Neue", Arial, sans-serif !important;
+  font-family: "Helvetica Neue", Arial, sans-serif !important;
   font-size: 13px !important;
   margin-top: 6px !important;
   margin-bottom: 6px !important;


### PR DESCRIPTION
This fixes some glitchy behavior in Chromium 27.0.1453.93 on Archlinux/Gnome 3.8.

I think what was happening was that some fonts that were rendered offscreen rendered with the default sans-serif font, but were sized as if they used the tiny default HN font, causing word overlap and unreadable text when I scrolled downwards in the comments section. Anyways, this makes all comments render with Helvetica Neue, which I think was always the intention.
