### PR TITLE
Use `white-space: pre-wrap` in comments to improve display.

### DIFF
--- a/style.css
+++ b/style.css
@@ -475,6 +475,7 @@ a.original_poster,
   max-width: 800px;
   font-family: font-family: "Helvetica Neue", Arial, sans-serif !important;
   line-height: 1.5em;
+  white-space: pre-wrap;
 }
 .comment, .dead {
   font-size: 13px !important;
@@ -495,6 +496,12 @@ a.original_poster,
   font-size: 13px !important;
   margin-top: 6px !important;
   margin-bottom: 6px !important;
+}
+
+/* Wrap <pre> tags (indented text) so they don't have an annoying horizontal scrollbar */
+pre {
+  white-space: pre-wrap;
+  margin-left: 1em;
 }
 
 /*make sure comment headers are on one line


### PR DESCRIPTION
Thanks for a great extension, it really improves HN.

This PR addresses two formatting annoyances I'd really like to fix.
### Wrapped Comments

One thing that bothers me a lot about HN is its comment formatting. It requires an extra newline between paragraphs that many commenters fail to use, causing whitespace to be lost between lines. This happens especially often with bulleted lists; they look fine in the editor, bad on the page.

This PR fixes word wrapping on comments:

Original (no HNES):
![original](http://www.ultraimg.com/images/cPRYE.png)

HNES:
![HNES](http://www.ultraimg.com/images/BniUK.png)

HNES with this PR:
![PR](http://www.ultraimg.com/images/p5AdW.png)
### Wrapped pre/code blocks

As you know, indented content in HN is placed inside a &lt;pre>&lt;code>{content}&lt;/code>&lt;/pre> block. This creates a very annoying horizontal scrollbar that makes the content unreadable. By adding `white-space: pre-wrap;` and a tiny bit of left margin, we can make them look much better.

HNES:
![HNES](http://www.ultraimg.com/images/2fnoH.png)

HNES with this PR:
![PR](http://www.ultraimg.com/images/IBizu.png)
