### PR TITLE
Fix the "Add comment" button position.

### DIFF
--- a/style.css
+++ b/style.css
@@ -274,6 +274,7 @@ a:hover {
 }
 /*submit/add comment button*/
 input[type="submit"] {
+  display: block;
   font-family: "Helvetica Neue", Arial, sans-serif;
   font-size: 13px;
   color: white;
@@ -402,6 +403,7 @@ form textarea {
   padding: 10px;
   height:80px;
   overflow: auto;
+  margin-bottom: 10px;
 }
 textarea, input {
   border-width: 1px;


### PR DESCRIPTION
It seems the "Add comment" button is now to the right of the text box, instead of below it (like originally in HN). This PR fixes that.

Before / after screenshot:

![hnes-btn](https://cloud.githubusercontent.com/assets/163961/3068640/05ba2ac6-e291-11e3-8b99-589fcf335762.png)
