### PR TITLE
Fixed topcolor setting

### DIFF
--- a/js/hn.js
+++ b/js/hn.js
@@ -743,9 +743,6 @@ var HN = {
     doUserProfile: function() {
       $('#content > td').attr('id', 'user-profile');
 
-      //remove topcolor setting as this will cause problems (untested)
-      $('tr > td[valign="top"]:contains("topcolor:")').parent().remove();
-
       var options = $('tr > td[valign="top"]');
       var user = options[0];
       var created = $(options[1]);
@@ -770,7 +767,16 @@ var HN = {
         var noprocrast = $(options[7]);
         var maxvisit = $(options[8]);
         var minaway = $(options[9]);
-        var delay = $(options[10]);
+		var delay;
+		if($('tr > td[valign="top"]:contains("topcolor:")').length) {
+			var topcolor = $(options[10]);
+			topcolor.addClass('select-option');
+        topcolor.next().append($('<span>Default: FF6600</span>'));
+			delay = $(options[11]);		
+		}
+		else{
+			delay = $(options[10]);				
+		}
 
         //fix spacing
         email.addClass('select-option'); 
@@ -1181,6 +1187,7 @@ var HN = {
       user_drop.click(user_drop_toggle);
       hidden_div.click(user_drop_toggle);
       hidden_div.hide();
+	  HN.setTopColor();
     },
     rewriteNavigation: function() {
         var topsel = $('.topsel');
@@ -1282,6 +1289,14 @@ var HN = {
       others.toggle();
     },
 
+	setTopColor: function(){
+	  var topcolor = document.getElementById("header").firstChild.getAttribute("bgcolor");
+	  if(topcolor.toLowerCase() != '#ff6600')
+	  {
+		document.getElementById("header").style.setProperty("background-color", topcolor, "important");
+	  }
+	},
+	
     setSearchInput: function(el, domain) {
       var text = "Search on " + domain;
       $("input[name='q']").val(text);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Hacker News Enhancement Suite",
     "short_name": "HNES",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "description": "Hacker News Enhanced.",
     "manifest_version": 2,
     "background": {


### PR DESCRIPTION
Fixes [issue #52](https://github.com/etcet/HNES/issues/52) in which the HN topcolor setting was ignored by HNES.

There are two issues with this feature that we might want to address in a future update.  Just like the vanilla HN topcolor, the text on the menu can still become unreadable if there isn't enough contrast between the color chosen and the default white and black text. Considering this is an enhancement suite, a nice additional feature would be to add some logic to adjust the primary and alternate text colors so that both are readable on the selected background. Secondly, the HNES nav drop menus used the same #d74937 that will be replaced if a topcolor is selected. While I could certainly see arguments for the contrary, I decided to keep it simple and not change the nav menu to match the topcolor. This could be changed in a future update if there is a demand.