### PR TITLE
Bugfix preventing page from rendering

### DIFF
--- a/js/hn.js
+++ b/js/hn.js
@@ -1286,7 +1286,7 @@ var HN = {
     },
 
 	setTopColor: function(){
-	  var topcolor = document.getElementById("header").firstChild.getAttribute("bgcolor");
+	  var topcolor = document.getElementById("header").children[0].getAttribute("bgcolor");
 	  if(topcolor.toLowerCase() != '#ff6600')
 	  {
 		document.getElementById("header").style.setProperty("background-color", topcolor, "important");


### PR DESCRIPTION
The code "document.getElementById("header").firstChild" seems to return a textNode, instead of intended DOM element. Using .children[0] seems to fix this.