### PR TITLE
Fix collapsing comments.

### DIFF
--- a/js/hn.js
+++ b/js/hn.js
@@ -375,7 +375,8 @@ var RedditComments = {
         .attr('title', 'Restore comment')
         .css('margin-left', def.prev().width() + 2 + 'px');
       // Hide everything but the comhead element.
-      def.find('div').siblings().slice(1).hide();
+      def.children('.comment').hide();
+      def.children('.reply').hide();
       def.prev().hide();
       el.addClass('collapsed');
     }

--- a/js/hn.js
+++ b/js/hn.js
@@ -374,7 +374,8 @@ var RedditComments = {
       $e.text("[+]" + child_str)
         .attr('title', 'Restore comment')
         .css('margin-left', def.prev().width() + 2 + 'px');
-      def.find('div').siblings().hide();
+      // Hide everything but the comhead element.
+      def.find('div').siblings().slice(1).hide();
       def.prev().hide();
       el.addClass('collapsed');
     }


### PR DESCRIPTION
When collapsing comments, the entire comment would disappear, including
the button to expand them. Fix the function so that only the text,
upvote button, and reply buttons are hidden.