### PR TITLE
Change behavior of hnes-new/hnes-new-parent when parent is also new

### DIFF
--- a/js/hn.js
+++ b/js/hn.js
@@ -148,10 +148,11 @@ var CommentTracker = {
         comment = RedditComments.nodeMap[id];
 
       if (id > last_id) {
-        comment.row.addClass('hnes-new');
+        comment.row.removeClass('hnes-new-parent').addClass('hnes-new');
         comment = comment.parent;
         while (comment && comment.level > 0) {
-          comment.row.addClass('hnes-new-parent');
+          if (!comment.row.hasClass('hnes-new'))
+            comment.row.addClass('hnes-new-parent');
           comment = comment.parent;
         }
       }


### PR DESCRIPTION
When looking at a previously viewed item, a person's eye follows the
trail of hnes-new-parent nodes looking for the hnes-new nodes. But with
the current behavior some of the hnes-new-parent nodes are themselves
new nodes and it's easy to miss.

This change makes sure that any new node is colored with hnes-new while
the previous nodes on the path get colored with hnes-new-parent like
before.