### PR TITLE
Upgrade deprecated function calls to their replacements

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,5 @@
 // Add event listeners
-chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
   console.log('REQUEST', request.method, request)
   if (request.method == "getAllLocalStorage") {
     sendResponse({data: localStorage});

--- a/js/hn.js
+++ b/js/hn.js
@@ -630,14 +630,14 @@ var HN = {
     },
 
     getLocalStorage: function(key, callback) {
-      chrome.extension.sendRequest({
+      chrome.runtime.sendMessage({
         method: "getLocalStorage",
         key: key
       }, callback);
     },
 
     setLocalStorage: function(key, value) {
-      chrome.extension.sendRequest(
+      chrome.runtime.sendMessage(
         { method: "setLocalStorage",
           key: key,
           value: value },
@@ -1617,7 +1617,7 @@ var HN = {
 //show new comment count on hckrnews.com
 if (window.location.host == "hckrnews.com") {
   $('ul.entries li').each(function() {
-    chrome.extension.sendRequest({method: "getLocalStorage", key: Number($(this).attr('id'))}, function(response) {
+    chrome.runtime.sendMessage({method: "getLocalStorage", key: Number($(this).attr('id'))}, function(response) {
       if (response.data != undefined) {
         var data = JSON.parse(response.data);
         var id = data.id;


### PR DESCRIPTION
`chrome.extension.sendRequest` [1] and `chrome.extension.onRequest` [2]
have been deprecated and replaced by `chrome.runtime.sendMessage` and
`chrome.runtime.onMessage` respectively. This change updates the use of
these functions.

A side effect of this change is partial Firefox compatibility.  With
these changes and an `applications` [3] object added to `manifest.json`,
the extension appears functional in Firefox. There are visual issues
when running in Firefox that should be addressed with CSS before
packaging and releasing as a Firefox addon.

References #54.

[1] https://developer.chrome.com/extensions/extension#method-sendRequest
[2] https://developer.chrome.com/extensions/extension#event-onRequest
[3] https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/applications