### PR TITLE
Refactor comments performance

### DIFF
--- a/background.js
+++ b/background.js
@@ -11,10 +11,24 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     localStorage[request.key] = request.value;
     sendResponse({});
   }
+  else if (request.method == "getUserData") {
+    var data = getUserData(request.usernames);
+    sendResponse({ data: data });
+  }
   else {
     sendResponse({});
   }
 });
+
+function getUserData(usernames) {
+  var results = {};
+  for (var i = 0; i < usernames.length; i++) {
+    var key = usernames[i],
+        value = localStorage[key];
+    results[key] = value;
+  }
+  return results;
+}
 
 //expire old entries
 (function() {

--- a/js/hn.js
+++ b/js/hn.js
@@ -1019,25 +1019,27 @@ var HN = {
         HN.upvoteUser(e, -1);
       });
 
-      $(document).on('click', '.tag, .tagText', function(e) {
+      $(document).on('click', '.hnes-tag, .hnes-tagText', function(e) {
       // Using .on() so that the event applies to all elements generated in the future
         HN.editUserTag(e);
       });
 
-      $(document).on('keyup', '.tagEdit', function(e) {
-        var code = e.keyCode || e.which;
-        var parent = $(e.target).parent();
+      $(document).on('keyup', '.hnes-tagEdit', function(e) {
+        var code = e.keyCode || e.which,
+            parent = $(e.target).parent(),
+            gp = parent.parent();
+
         if (code === 13) { // Enter
-          var author = parent.find('.commenter').text();
-          var tagEdit = parent.find('.tagEdit');
+          var author = gp.find('.commenter').text(),
+              tagEdit = parent.find('.hnes-tagEdit');
           HN.setUserTag(author, tagEdit.val());
+          parent.removeClass('edit');
         }
         if (code === 27) { // Escape
-          var tagText = parent.find('.tagText');
-          var tagEdit = parent.find('.tagEdit');
-          tagText.show();
-          tagEdit.val(tagText.text())
-                 .hide();
+          var tagText = gp.find('.hnes-tagText'),
+              tagEdit = parent.find('.hnes-tagEdit');
+          tagEdit.val(tagText.text());
+          parent.removeClass('edit');
         }
       });
 
@@ -1108,34 +1110,27 @@ var HN = {
     },
 
     addUserTag: function(el, tag) {
-      var username = el.text();
-      el.after(
-          $('<img/>').addClass('tag')
-                     .attr('src', chrome.extension.getURL('/images/tag.svg'))
-                     .attr('title', 'Tag user')
-      );
-      el.after(
-        $('<span/>').addClass('tagText')
-                    .text(tag)
-                    .attr('title', 'User tag')
-      );
-      el.after(
-        $('<input/>').attr('type', 'text')
-                     .addClass('tagEdit')
-                     .attr('placeholder', 'Tag ' + username)
-                     .val(tag)
-      )
-      el.parent().find('.tagEdit').hide();
+      var username = el.text(),
+          tagContainer = $('<span>').addClass('hnes-tag-cont');
+
+      tagContainer.append(
+          $('<img/>').addClass('hnes-tag')
+              .attr('src', chrome.extension.getURL('/images/tag.svg'))
+              .attr('title', 'Tag user'),
+          $('<span/>').addClass('hnes-tagText')
+              .text(tag)
+              .attr('title', 'User tag'),
+          $('<input/>').attr('type', 'text')
+              .addClass('hnes-tagEdit')
+              .attr('placeholder', 'Tag ' + username)
+              .val(tag)
+      ).insertAfter(el);
     },
 
     editUserTag: function(e) {
-      var parent = $(e.target).parent();
-      var tagText = parent.find('.tagText');
-      var tagEdit = parent.find('.tagEdit');
-      
-      // Go in edit mode
-      tagText.hide();
-      tagEdit.show();
+      var parent = $(e.target).parent(),
+          tagEdit = parent.find('.hnes-tagEdit');
+      parent.addClass('edit');
       tagEdit.focus();
     },
 
@@ -1153,16 +1148,12 @@ var HN = {
 
       var commenter = $('.commenter:contains('+author+')');
       for (i = 0; i < commenter.length; i++) {
-        var tagText = $(commenter[i]).parent().find('.tagText');
-        var tagEdit = $(commenter[i]).parent().find('.tagEdit');
+        var tagText = $(commenter[i]).parent().find('.hnes-tagText'),
+            tagEdit = $(commenter[i]).parent().find('.hnes-tagEdit');
 
         // Change it all to the new value:
         tagText.text(tag);
         tagEdit.val(tag);
-
-        // Show the text, hide the input:
-        tagEdit.hide();
-        tagText.show();
       }
     },
 

--- a/style.css
+++ b/style.css
@@ -784,16 +784,16 @@ body .votearrow.rotate180 {
     border-right: 2px solid #BC9B85;
 }
 
-.tag, .tagText:not(:empty) {
+.hnes-tag, .hnes-tagText:not(:empty) {
     margin-left: 4px;
     cursor: pointer;
 }
 
-.tag {
+.hnes-tag {
     margin-bottom: -2px;
 }
 
-.tagText:not(:empty) {
+.hnes-tagText:not(:empty) {
   border-color: #828282;
   border-radius: 1px;
   border-width: 1px;
@@ -801,8 +801,16 @@ body .votearrow.rotate180 {
   padding: 0 4px;
 }
 
-.tagEdit {
+.hnes-tagEdit {
     padding-left: 2px;
     width: 120px;
     margin: 0 4px;
+    display: none;
+}
+
+.hnes-tag-cont.edit .hnes-tag {
+    display: none;
+}
+.hnes-tag-cont.edit .hnes-tagEdit {
+    display: initial;
 }


### PR DESCRIPTION
HNES performs pretty miserable on long threads.  For example, see the [Brexit announcement thread](https://news.ycombinator.com/item?id=11966167), which contains ~3,000 comments.  It's mostly forced reflow, thrashing, and expensive messaging.  I reworked the biggest offenders.  There's plenty more to do, but this takes page load on my 2015 MBP from ~2 minutes to 8 sec.
