### PR TITLE
Fix #112

### DIFF
--- a/js/hn.js
+++ b/js/hn.js
@@ -1015,7 +1015,7 @@ var HN = {
       var commenters = $('.commenter');
       HN.getUserInfo(commenters);
 
-      var vote_links = commentsblock.find($('a[onclick="return vote(this)"]'));
+      var vote_links = commentsblock.find($('a[onclick^="return vote(this"]'));
       var upvote_links = $(vote_links).filter('a[id^="up_"]');
       var downvote_links = $(vote_links).filter('a[id^="down_"]');
       upvote_links.click(function(e) {


### PR DESCRIPTION
I've got to preface the explanation of this PR by saying that I found issue #112 a bit weird at first. I was able to reproduce it in the current master, in my fork, but also in previous releases. Also, I didn't recall this from happening previously &mdash; I would definitely have noticed.

It turns out that the issue doesn't stem directly from an error in the HNES code, but rather from the fact that HN have changed their code a little bit. The HTML for the upvote arrow went from what I think was:

    <a ... onclick="return vote(this) ...>

To this:

    <a ... onclick="return vote(this, "up") ...>

This subtle change messed with a single line of HNES. Indeed, in `addInfoToUsers()`, there is this one line that goes:

    var vote_links = commentsblock.find($('a[onclick="return vote(this)"]'));

That would match the old anchor tags' markup, but not the new ones. So in this PR, I've made it search for anchor tags whose `onclick` attribute *starts* with `return vote(this`, which works for now. And as long as HN keeps the same basic syntax for their `vote()` function (which I think is very likely), this will work.