### PR TITLE
Comment Count Fallback

### DIFF
--- a/style.css
+++ b/style.css
@@ -107,6 +107,10 @@ table tr td {
 .comments:hover {
   color: #dd4b39;
 }
+/* show a fallback if parsing comment number fails */
+.comments:empty::before {
+  content: '💬';
+}
 
 /*spacing for comment and score tally*/
 #index-body #content table td:first-child {


### PR DESCRIPTION
Fallback for problem described in etcet/HNES#123. Empty comment anchor tags are displayed with the content '💬', which gives a visual indication of where to click to view comments, even if parsing the comment count fails.

Before:
![Without Patch](https://cloud.githubusercontent.com/assets/742407/17645956/2b76eb64-616a-11e6-9330-585db115be1e.png)
After:
![With Patch](https://cloud.githubusercontent.com/assets/3820879/17650294/14a37ff2-6218-11e6-925f-49fdc4491d7a.png)

This patch strictly addresses the poor behavior in the event of a failure, not the underlying cause of the failure. Patch #124 fixes the underlying cause of failure, but this patch provides a dash of future proofing. 