### PR TITLE
Fix non-breaking spaces in comment and vote counts

### DIFF
--- a/js/hn.js
+++ b/js/hn.js
@@ -1215,7 +1215,7 @@ var HN = {
           score.text('');
         else
           comments.text(
-            comments.text().substring(0, comments.text().indexOf(' '))
+            comments.text().substring(0, comments.text().indexOf('\xa0'))
           );
         comments.addClass("comments")
                 .attr('title', 'Comments');

--- a/js/hn.js
+++ b/js/hn.js
@@ -1202,7 +1202,7 @@ var HN = {
         if (score.length == 0)
           score = $("<span/>").text('0');
         else
-          score.text(score.text().substring(0, score.text().indexOf(' ')));
+          score.text(score.text().substring(0, score.text().indexOf('\xa0')));
         score.addClass("score").attr('title', 'Points');
 
         if (comments.text() == "discuss" || /ago$/.test(comments.text()))


### PR DESCRIPTION
This is based off of @bsloane1650 's changes, except I cherry-picked just his commit to fix the space issue on the comment count, and added a similar change to the vote count. @bsloane1650, I think something went wrong with your Git branch, your merge looks like it's trying to merge in ~150 duplicate commits.