### PR TITLE
Remove "Collapse comment" tooltip

### DIFF
--- a/js/hn.js
+++ b/js/hn.js
@@ -269,8 +269,7 @@ var RedditComments = {
     var self = this;
 
     var collapse_button = $('<a/>').addClass('collapse')
-                                      .text('[\u2013]')
-                                      .attr('title', 'Collapse comment');
+                                      .text('[\u2013]');
     var link_to_parent = $('<span/>').text(' | ')
                                      .append($('<a/>')
                                      .attr('href', '#')


### PR DESCRIPTION
To better match the default collapse comments button

It's also annoying when you're going down the page with the mouse over the buttons and the title obscures the content below it.
