### PR TITLE
Basic Firefox Support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -42,5 +42,10 @@
     "web_accessible_resources": [
       "images/spin.gif",
       "images/tag.svg"
-    ]
+    ],
+    "applications": {
+      "gecko": {
+        "id": "hnes@etcet.net"
+      }
+    }
 }

--- a/style.css
+++ b/style.css
@@ -113,13 +113,23 @@ table tr td {
 }
 
 /*spacing for comment and score tally*/
+#index-body #content table { /* Firefox */
+  width: 100%;
+  max-width: 1170px;
+}
 #index-body #content table td:first-child {
   width: 80px;
+  max-width: 80px; /* Firefox */
   text-align: right;
 }
 #index-body #content table td:nth-child(2) {
   width: 64px;
+  max-width: 64px; /* Firefox */
   text-align: right;
+}
+
+#index-body #content table td.title { /* Firefox */
+  width: auto;
 }
 
 /*spacing between story lines*/
@@ -371,6 +381,7 @@ div > .comhead {
 .title:first-child {
   padding-left: 5px !important;
 }
+.pagetop a:hover,
 .pagetop a:active {
   color: #000;
 }
@@ -391,7 +402,7 @@ div > .comhead {
   display: block;
 }
 .pagetop {
-  font-size: 10px;
+  font-size: 10pt;
   font-family: "Helvetica Neue", Arial, sans-serif !important;
 }
 .pagetop b a {
@@ -541,14 +552,15 @@ td::selection,
 html body center table tbody tr td table tbody tr td a img[src="http://ycombinator.com/images/y18.gif"],
 html body center table tbody tr td table tbody tr td a img[src="y18.gif"],
 html body center table tbody tr td table tbody tr td a img[src="/sslyc/images/y18.gif"] {
-  zoom: 60%;
+  /*zoom: 60%;*/
   height: 0px !important;
   width: 0px !important;
   /* these numbers match the new image's dimensions */
-  padding-left: 36px !important;
-  padding-top: 36px !important;
+  padding-left: 18px !important;
+  padding-top: 18px !important;
   border-color: 0px 0px 3px #000;
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAIAAABuYg/PAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA+FpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ1M1IE1hY2ludG9zaCIgeG1wOkNyZWF0ZURhdGU9IjIwMTEtMDYtMzBUMjI6Mjc6MDUtMDc6MDAiIHhtcDpNb2RpZnlEYXRlPSIyMDExLTA3LTAxVDA2OjAxKzE3OjAwIiB4bXA6TWV0YWRhdGFEYXRlPSIyMDExLTA3LTAxVDA2OjAxKzE3OjAwIiBkYzpmb3JtYXQ9ImltYWdlL3BuZyIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDpGQTNBQkM1RjlCQzkxMUUwQTFDNUUxMkQzOUQ0MjY0MCIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDpGQTNBQkM2MDlCQzkxMUUwQTFDNUUxMkQzOUQ0MjY0MCI+IDx4bXBNTTpEZXJpdmVkRnJvbSBzdFJlZjppbnN0YW5jZUlEPSJ4bXAuaWlkOkZBM0FCQzVEOUJDOTExRTBBMUM1RTEyRDM5RDQyNjQwIiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOkZBM0FCQzVFOUJDOTExRTBBMUM1RTEyRDM5RDQyNjQwIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+HtChkAAAAS9JREFUeNpifH388Kdls3/duclAS8Cmos4Xlcp4M9Lz34d3DLQHTAJCTPSxCQiAFjEx0BGMWjZq2Qi1jIWgClZxSeX56yHsV7MmvNuwAi7F7+otWVgLYd9NDPz98jmlPgMa8WbpHAhbJDqFmZsXwgYyxNMKIez3G1cStInYYHy/YeXvVy9Aqrl5xNILoBbHpAC5oHLo65c3S+ZQLc7+fv38amY/NOhcvLn0jIBhK+gfDhF53tcMVECdOIOAz8cPfrt8nkvXEByYqXBxoCBQivqp8XlfE4QBtBJiK7IglS1DTikQAOQSky7IzGfwlAKy+9ULIJeGmRqYED7u3gJhAxlEpovRsnEIW8Z43dN8NBhHLRu1bNQyMi1jFhKhj01Ai5gE0guBfUI6dDuBFgEEGAAManVd0fe0qQAAAABJRU5ErkJggg%3D%3D) no-repeat !important;
+  background-size: cover !important;
 }
 /* Submit Page */
 form[action="/r"] table {
@@ -728,12 +740,12 @@ body#login-body {
 /* Note, it is a child of body so that it has a higher specificity than the default style */
 body .votearrow {
   /* SVG arrow so that it scales to high-resolution displays */
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="10" height="10"><path d="M 1,9 5,1 9,9 z" fill="#828282"/></svg>');
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="10" height="10"><path d="M 1,9 5,1 9,9 z" fill="%23828282"/></svg>');
 }
 /* Instead of simply rotating the entire element, the svg is actually manually flipped.
    This results in a pixel perfect reflection of the up arrow */
 body .votearrow.rotate180 {
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="10" height="10"><path d="M 1,1 5,9 9,1 z" fill="#828282"/></svg>');
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="10" height="10"><path d="M 1,1 5,9 9,1 z" fill="%23828282"/></svg>');
   transform: none;
 }
 


### PR DESCRIPTION
This PR provides minor CSS tweaks to make HNES usable on Firefox.

This is testable on Firefox (dev edition) by going to `about:debugging`, clicking the "Load Temporary Add-on" button, and selecting the manifest file from your local copy of this repo.

I did have to add a max-width to the `.itemlist` table. I arbitrarily chose 1170px but anything would work.

Before tweaks:
<img width="1232" alt="screen shot 2017-01-05 at 3 02 42 pm" src="https://cloud.githubusercontent.com/assets/430255/21697515/56af4820-d358-11e6-9670-f5eb275399d5.png">

After tweaks:
<img width="1232" alt="screen shot 2017-01-05 at 3 03 04 pm" src="https://cloud.githubusercontent.com/assets/430255/21697524/608cec76-d358-11e6-81a8-86a14b62c50f.png">

Chrome for comparison: (Unmodified CSS)
![screen shot 2017-01-05 at 3 11 32 pm](https://cloud.githubusercontent.com/assets/430255/21697713/4aab10d0-d359-11e6-9498-517bd55ab89c.png)
