### PR TITLE
fix spacing and reply button for '/item' pages

### DIFF
--- a/js/hn.js
+++ b/js/hn.js
@@ -771,8 +771,8 @@ var HN = {
         //linkify self-post text
         $('.item-header tr:nth-child(3)').addClass('self-post-text').linkify();
 
-        //fix spacing issue #86
-        $(".item-header td[colspan='2']").attr('colspan', '1');
+	// move reply button to new line.
+        $(".item-header input[type='submit']").css("display", "block");
 
         var more = $('#more');
         //recursively load more pages on closed thread


### PR DESCRIPTION
Spacing on /item pages has been botched since I started using HNES over a year ago.

This fixes the issue by again making the first 0px-width element `colspan='2'`, and changing reply to `display: block`.

**Before:** 
![screen shot 2017-07-27 at 11 09 39](https://user-images.githubusercontent.com/19675639/28682976-1ea24dfc-72bc-11e7-9a3a-b1c9f976464b.png)

**After:**
![screen shot 2017-07-27 at 11 04 56](https://user-images.githubusercontent.com/19675639/28682986-26a8c30a-72bc-11e7-9b68-39252d1f80d8.png)
