### PR TITLE
Change Karma required to create poll

### DIFF
--- a/js/hn.js
+++ b/js/hn.js
@@ -850,7 +850,7 @@ var HN = {
 
         var current_karma = parseInt(karma.next().text());
         var karma_for_flag = 20;
-        var karma_for_polls = 200;
+        var karma_for_polls = 201;
         var karma_for_downvotes = 500;
         var can_flag_msg;
         var can_create_polls_msg;


### PR DESCRIPTION
A user needs more than 200 karma to create a poll, not 200 or more. Karma required for flagging, and karma required to downvote are likely similar (21, and 501 respectively), but I'm not currently able to verify this. See https://youtu.be/hT6oTG2y8BA for example.