### PR TITLE
Restore voting arrows & logo

### DIFF
--- a/style.css
+++ b/style.css
@@ -254,27 +254,6 @@ body#item-body .title {
   line-height: 18px;
   font-weight: medium;
 }
-/*upvote arrow*/
-#item-body img[src="http://ycombinator.com/images/grayarrow.gif"],
-#item-body img[src="/sslyc/images/grayarrow.gif"] {
-  position: relative;
-  top: -4px;
-  position-right: 3px;
-}
-/*upvotes on index page*/
-#index-body #content td:nth-child(3) {
-  width: 30px;
-}
-#index-body #content td:nth-child(3) center {
-  position: absolute;
-  top: 5px;
-}
-/* poll vote ups */
-#item-body .item-header tr:last-child img[src="http://ycombinator.com/images/grayarrow.gif"],
-#item-body .item-header tr:last-child img[src="/sslyc/images/grayarrow.gif"] {
-  top: 0px;
-  position-right: 0px;
-}
 
 /*make self posts text black*/
 .item-header tr:nth-child(3) td {
@@ -507,11 +486,7 @@ pre {
 #comment-table {
   width: 100%;
 }
-/*and force up arrow width for said bugfix*/
-img[src="http://ycombinator.com/images/grayarrow.gif"],
-img[src="/sslyc/images/grayarrow.gif"] {
-  width: 10px;
-}
+
 .reply_form {
   width: 300px;
 }
@@ -615,31 +590,6 @@ form[action="/r"] input[type="submit"] {
 td #more.link-highlight {
   border: none;
   padding: 5px 18px 5px 8px !important;
-}
-
-div.up-arrow, div.down-arrow {
-  width: 0;
-  height: 0;
-  border-left: 5pt solid transparent;
-  border-right: 5pt solid transparent;
-}
-div.up-arrow {
-  border-bottom: 7pt solid #999;
-}
-
-div.down-arrow {
-  border-top: 7pt solid #999;
-  margin-top: 7px;
-}
-
-div.last-arrow {
-  margin-right: 4pt;
-}
-
-div.postlist-arrow {
-  display: block;
-  margin-top: 4pt;
-  margin-left: 4pt;
 }
 
 #alert {

--- a/style.css
+++ b/style.css
@@ -169,7 +169,7 @@ a.comments:hover {
 .nav-links a:hover,
 .more-arrow:hover,
 .more-arrow:hover a,
-.more-arrow a.active, 
+.more-arrow a.active,
 .nav-active-link {
   color: #fff !important;
 }
@@ -536,25 +536,7 @@ td::selection,
   background: #dd4b39 !important;
   color: #fff;
 }
-.icon {
-  width: 36px;
-  height: 36px;
-  border: 1px solid #fff;
-  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAIAAABuYg/PAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA+FpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ1M1IE1hY2ludG9zaCIgeG1wOkNyZWF0ZURhdGU9IjIwMTEtMDYtMzBUMjI6Mjc6MDUtMDc6MDAiIHhtcDpNb2RpZnlEYXRlPSIyMDExLTA3LTAxVDA2OjAxKzE3OjAwIiB4bXA6TWV0YWRhdGFEYXRlPSIyMDExLTA3LTAxVDA2OjAxKzE3OjAwIiBkYzpmb3JtYXQ9ImltYWdlL3BuZyIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDpGQTNBQkM1RjlCQzkxMUUwQTFDNUUxMkQzOUQ0MjY0MCIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDpGQTNBQkM2MDlCQzkxMUUwQTFDNUUxMkQzOUQ0MjY0MCI+IDx4bXBNTTpEZXJpdmVkRnJvbSBzdFJlZjppbnN0YW5jZUlEPSJ4bXAuaWlkOkZBM0FCQzVEOUJDOTExRTBBMUM1RTEyRDM5RDQyNjQwIiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOkZBM0FCQzVFOUJDOTExRTBBMUM1RTEyRDM5RDQyNjQwIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+HtChkAAAAS9JREFUeNpifH388Kdls3/duclAS8Cmos4Xlcp4M9Lz34d3DLQHTAJCTPSxCQiAFjEx0BGMWjZq2Qi1jIWgClZxSeX56yHsV7MmvNuwAi7F7+otWVgLYd9NDPz98jmlPgMa8WbpHAhbJDqFmZsXwgYyxNMKIez3G1cStInYYHy/YeXvVy9Aqrl5xNILoBbHpAC5oHLo65c3S+ZQLc7+fv38amY/NOhcvLn0jIBhK+gfDhF53tcMVECdOIOAz8cPfrt8nkvXEByYqXBxoCBQivqp8XlfE4QBtBJiK7IglS1DTikQAOQSky7IzGfwlAKy+9ULIJeGmRqYED7u3gJhAxlEpovRsnEIW8Z43dN8NBhHLRu1bNQyMi1jFhKhj01Ai5gE0guBfUI6dDuBFgEEGAAManVd0fe0qQAAAABJRU5ErkJggg%3D%3D) no-repeat !important;
-}
-html body center table tbody tr td table tbody tr td a img[src="http://ycombinator.com/images/y18.gif"],
-html body center table tbody tr td table tbody tr td a img[src="y18.gif"],
-html body center table tbody tr td table tbody tr td a img[src="/sslyc/images/y18.gif"] {
-  /*zoom: 60%;*/
-  height: 0px !important;
-  width: 0px !important;
-  /* these numbers match the new image's dimensions */
-  padding-left: 18px !important;
-  padding-top: 18px !important;
-  border-color: 0px 0px 3px #000;
-  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAIAAABuYg/PAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA+FpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ1M1IE1hY2ludG9zaCIgeG1wOkNyZWF0ZURhdGU9IjIwMTEtMDYtMzBUMjI6Mjc6MDUtMDc6MDAiIHhtcDpNb2RpZnlEYXRlPSIyMDExLTA3LTAxVDA2OjAxKzE3OjAwIiB4bXA6TWV0YWRhdGFEYXRlPSIyMDExLTA3LTAxVDA2OjAxKzE3OjAwIiBkYzpmb3JtYXQ9ImltYWdlL3BuZyIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDpGQTNBQkM1RjlCQzkxMUUwQTFDNUUxMkQzOUQ0MjY0MCIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDpGQTNBQkM2MDlCQzkxMUUwQTFDNUUxMkQzOUQ0MjY0MCI+IDx4bXBNTTpEZXJpdmVkRnJvbSBzdFJlZjppbnN0YW5jZUlEPSJ4bXAuaWlkOkZBM0FCQzVEOUJDOTExRTBBMUM1RTEyRDM5RDQyNjQwIiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOkZBM0FCQzVFOUJDOTExRTBBMUM1RTEyRDM5RDQyNjQwIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+HtChkAAAAS9JREFUeNpifH388Kdls3/duclAS8Cmos4Xlcp4M9Lz34d3DLQHTAJCTPSxCQiAFjEx0BGMWjZq2Qi1jIWgClZxSeX56yHsV7MmvNuwAi7F7+otWVgLYd9NDPz98jmlPgMa8WbpHAhbJDqFmZsXwgYyxNMKIez3G1cStInYYHy/YeXvVy9Aqrl5xNILoBbHpAC5oHLo65c3S+ZQLc7+fv38amY/NOhcvLn0jIBhK+gfDhF53tcMVECdOIOAz8cPfrt8nkvXEByYqXBxoCBQivqp8XlfE4QBtBJiK7IglS1DTikQAOQSky7IzGfwlAKy+9ULIJeGmRqYED7u3gJhAxlEpovRsnEIW8Z43dN8NBhHLRu1bNQyMi1jFhKhj01Ai5gE0guBfUI6dDuBFgEEGAAManVd0fe0qQAAAABJRU5ErkJggg%3D%3D) no-repeat !important;
-  background-size: cover !important;
-}
+
 /* Submit Page */
 form[action="/r"] table {
   width: 400px;
@@ -729,18 +711,6 @@ body#login-body {
 }
 #login-body a:hover {
   text-decoration: underline;
-}
-
-/* Note, it is a child of body so that it has a higher specificity than the default style */
-body .votearrow {
-  /* SVG arrow so that it scales to high-resolution displays */
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="10" height="10"><path d="M 1,9 5,1 9,9 z" fill="%23828282"/></svg>');
-}
-/* Instead of simply rotating the entire element, the svg is actually manually flipped.
-   This results in a pixel perfect reflection of the up arrow */
-body .votearrow.rotate180 {
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="10" height="10"><path d="M 1,1 5,9 9,1 z" fill="%23828282"/></svg>');
-  transform: none;
 }
 
 .hnes-age,


### PR DESCRIPTION
HN recently updated the content-security-policy to restrict image permissions which caused the vote buttons and the logo image to disappear on the page.  This change simply removes those CSS elements and allows the page to render properly, if not exactly the way it was originally intended.

NOTE: This accomplishes the same thing as PR #152 but that commit reworks the CSS and this one removes it and allows the native CSS through.