### PR TITLE
Tighten up the replies left margin

### DIFF
--- a/style.css
+++ b/style.css
@@ -772,7 +772,7 @@ body#login-body {
 }
 
 #hnes-comments .replies {
-  margin: 8px 0 0 30px;
+  margin: 8px 0 0 15px;
 }
 
 .replies:empty {


### PR DESCRIPTION
Feels like it is just a little bit too wide on heavily nested comments.

![image](https://user-images.githubusercontent.com/85355/46554517-bfd40800-c90a-11e8-9896-1a33894f8c56.png)
