### PR TITLE
Fix link opening shortcut functionality

### DIFF
--- a/js/hn.js
+++ b/js/hn.js
@@ -1840,7 +1840,7 @@ var HN = {
 
     open_story: function(new_tab){
       if ($('.on_story').length != 0) {
-        var story = $('.on_story .title > a');
+        var story = $('.on_story .title .titleline > a');
         if (new_tab) {
           $('.on_story .title').addClass("link-highlight");
           window.open(story.attr("href"));


### PR DESCRIPTION
This change fixes issues with O, L, and B shortcuts not opening the selected link.

I assume there was a change to hacker news native HTML which broke the old code, but this works reliably.