### PR TITLE
Support manifest version 3 

### DIFF
--- a/js/hn.js
+++ b/js/hn.js
@@ -63,7 +63,7 @@ var InlineReply = {
       $(this).attr("value","Posting...");
       //Add loading spinner
       image = $('<img style="vertical-align:middle;margin-left:5px;"/>');
-      image.attr('src',chrome.extension.getURL("images/spin.gif"));
+      image.attr('src',chrome.runtime.getURL("images/spin.gif"));
       $(this).after(image);
       //Post
       InlineReply.postCommentTo(link, domain, text, $(this));
@@ -261,7 +261,7 @@ var CommentTracker = {
   }
 }
 
-var unvoteImg = chrome.extension.getURL("images/unvote.gif");
+var unvoteImg = chrome.runtime.getURL("images/unvote.gif");
 
 class HNComments {
   constructor(storyId) {
@@ -462,7 +462,7 @@ class HNComments {
 
     c.el = commentEl;
 
-    tagImageEl.src = chrome.extension.getURL('/images/tag.svg');
+    tagImageEl.src = chrome.runtime.getURL('/images/tag.svg');
 
     commentEl.id = c.id;
     commentEl.classList.add(`level-${oddOrEven}`);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Hacker News Enhancement Suite",
     "short_name": "HNES",
-    "version": "1.6.0.3",
+    "version": "1.7.0.0",
     "description": "Hacker News Enhanced.",
     "manifest_version": 3,
     "background": {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "short_name": "HNES",
     "version": "1.6.0.3",
     "description": "Hacker News Enhanced.",
-    "manifest_version": 2,
+    "manifest_version": 3,
     "background": {
       "scripts": ["background.js"]
     },
@@ -55,9 +55,22 @@
       }
     ],
     "web_accessible_resources": [
-      "images/spin.gif",
-      "images/unvote.gif",
-      "images/tag.svg",
-      "templates/comment.html"
+    {
+      "resources": [
+        "images/spin.gif",
+        "images/unvote.gif",
+        "images/tag.svg",
+        "templates/comment.html"
+      ],
+      "matches": [
+        "http://news.ycombinator.com/*",
+        "https://news.ycombinator.com/*",
+        "http://news.ycombinator.net/*",
+        "https://news.ycombinator.net/*",
+        "http://hackerne.ws/*",
+        "https://hackerne.ws/*",
+        "http://news.ycombinator.org/*",
+        "https://news.ycombinator.org/*"]
+      }
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,8 @@
     "description": "Hacker News Enhanced.",
     "manifest_version": 3,
     "background": {
-      "scripts": ["background.js"]
+      "service_worker": "service_worker.js",
+      "type": "module"
     },
     "permissions": [
       "storage",

--- a/service_worker.js
+++ b/service_worker.js
@@ -2,13 +2,13 @@
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
   console.log('REQUEST', request.method, request)
   if (request.method == "getAllLocalStorage") {
-    sendResponse({data: localStorage});
+    sendResponse({data: chrome.storage.local});
   }
   else if (request.method == "getLocalStorage") {
-    sendResponse({data: localStorage[request.key]});
+    sendResponse({data: chrome.storage.local[request.key]});
   }
   else if (request.method == "setLocalStorage") {
-    localStorage[request.key] = request.value;
+    chrome.storage.local[request.key] = request.value;
     sendResponse({});
   }
   else if (request.method == "getUserData") {
@@ -24,7 +24,7 @@ function getUserData(usernames) {
   var results = {};
   for (var i = 0; i < usernames.length; i++) {
     var key = usernames[i],
-        value = localStorage[key];
+        value = chrome.storage.local[key];
     results[key] = value;
   }
   return results;
@@ -32,10 +32,10 @@ function getUserData(usernames) {
 
 //expire old entries
 (function() {
-  for (i=0; i<localStorage.length; i++) {
-    var info = JSON.parse(localStorage[localStorage.key(i)]);
+  for (i=0; i<chrome.storage.local.length; i++) {
+    var info = JSON.parse(chrome.storage.local[chrome.storage.local.key(i)]);
     var now = new Date().getTime();
     if (now > info.expire)
-      localStorage.removeItem(localStorage.key(i));
+      chrome.storage.local.removeItem(chrome.storage.local.key(i));
   }
 });


### PR DESCRIPTION
Manifest v3 has been required since June 2025. Extensions running with Manifest v2 are no longer working in Chrome. This PR closes #180, #187, #188 and #189 and will allow the extension to be loaded in recent versions of Chrome.